### PR TITLE
Fix "ghprbPullId: unbound variable" error

### DIFF
--- a/prepare_environment.sh
+++ b/prepare_environment.sh
@@ -18,7 +18,7 @@ cat jenkins-env \
     | sed 's/^/export /g' \
     > /tmp/jenkins-env
 source /tmp/jenkins-env
-if [[ ! -z "${ghprbPullId}" ]] && [[ ! -z "${ghprbSourceBranch}" ]]; then
+if [[ ! -z "${ghprbPullId:-}" ]] && [[ ! -z "${ghprbSourceBranch:-}" ]]; then
   echo 'Checking out to Github PR branch'
   git fetch origin pull/${ghprbPullId}/head:${ghprbSourceBranch}
   git checkout ${ghprbSourceBranch}


### PR DESCRIPTION
Latest Che [build](https://ci.centos.org/view/Devtools/job/devtools-build-run-che-build-master/341/console) failed with the following error:

```
prepare_environment.sh: line 21: ghprbPullId: unbound variable
```

This is probably because `set -u` is configured by default. To avoid the error we have used bash parameter expansion.