### PR TITLE
Remove file

### DIFF
--- a/cico_run_EE_tests.sh
+++ b/cico_run_EE_tests.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-# When yaml job is update, remove this file
-source ./cico/cico_run_EE_tests.sh
-
-


### PR DESCRIPTION
As changes to yaml were merged to master, scripts are run directly from /cico folder and there is no need for file cico_run_EE_tests.sh in root dir. 