### PR TITLE
Timeout added (300 seconds).

### DIFF
--- a/che-start-workspace/osioperf.py
+++ b/che-start-workspace/osioperf.py
@@ -176,7 +176,13 @@ class TokenBehavior(TaskSet):
 			response.failure("Got wrong response: [" + content + "]")
 
 	def waitForWorkspaceToStart(self, id):
+		timeout_in_seconds = 300
 		while self.getWorkspaceStatus(id) != "RUNNING":
+			now = time.time()
+			if now - self.start > timeout_in_seconds:
+				events.request_failure.fire(request_type="REPEATED_GET", name="timeForStartingWorkspace",response_time=self._tick_timer(), exception="Workspace wasn't able to start in " + timeout_in_seconds + " seconds.")
+				print "Workspace wasn't able to start in " + timeout_in_seconds + " seconds."
+				return
 			print "Workspace id "+id+" is still not in state RUNNING"
 			self.wait()
 		print "Workspace id "+id+" is RUNNING"
@@ -234,7 +240,6 @@ class TokenBehavior(TaskSet):
 	def _tick_timer(self):
 		self.stop = time.time()
 		ret_val = (self.stop - self.start) * 1000
-		self.start = self.stop
 		return ret_val
 
 	def deleteExistingWorkspaces(self):

--- a/che-start-workspace/run.sh
+++ b/che-start-workspace/run.sh
@@ -211,13 +211,13 @@ function distribution_2_csv {
  echo "Check for errors in Locust master log"
 
  REPORT_COUNT=`wc -l < $JOB_BASE_NAME-$BUILD_NUMBER-report_distribution.csv`
-
+ EXPECTED_REPORT_COUNT=9
  EXIT_CODE=0
  if [[ "0" -ne `cat $JOB_BASE_NAME-$BUILD_NUMBER-locust-master.log | grep 'Error report' | wc -l` ]]; then
     echo 'THERE WERE ERRORS OR FAILURES WHILE SENDING REQUESTS';
     EXIT_CODE=1;
- elif [[ REPORT_COUNT -ne "8" ]]; then
-    echo "THERE WERE NOT CORRECT AMOUNT OF RECORDS IN REPORT FILE expected 9 gotten $REPORT_COUNT";
+ elif [[ REPORT_COUNT -ne $EXPECTED_REPORT_COUNT ]]; then
+    echo "THERE WERE NOT CORRECT AMOUNT OF RECORDS IN REPORT FILE expected $EXPECTED_REPORT_COUNT gotten $REPORT_COUNT";
     EXIT_CODE=1;
  else
     echo 'NO ERRORS OR FAILURES DETECTED';


### PR DESCRIPTION
Timeout for starting workspace is set to 300 seconds. If workspace doesn't start, it invokes request_failure event, removes the workspace and starts again. 