### PR TITLE
Fixing PT tests

### DIFF
--- a/che-start-workspace/README.md
+++ b/che-start-workspace/README.md
@@ -110,7 +110,7 @@ So the environment variable is set `RUN_LOCALLY=true`.
 To run the test, configure the test in `_setenv.sh` file and run the `run.sh` script.
 
 To update jenkins job use this syntax (not working for last version of jenkins job builder):
-´´´
+```
 sudo PYTHONHTTPSVERIFY=0 jenkins-jobs --conf jenkins_jobs.ini update job.yml
-´´´
+```
 and update jenkins_job.ini with your credentials. 

--- a/che-start-workspace/osioperf.py
+++ b/che-start-workspace/osioperf.py
@@ -107,7 +107,6 @@ class TokenBehavior(TaskSet):
 	id = ""
 
 	def on_start(self):
-		events.quitting += self.on_stop
 		global _currentUser, _users, _userLock, _userTokens, _userRefreshTokens
 		_userLock.acquire()
 		self.taskUser = _currentUser
@@ -118,16 +117,6 @@ class TokenBehavior(TaskSet):
 		_userLock.release()
 		self.taskUserToken = _userTokens[self.taskUser]
 		self.taskUserRefreshToken = _userRefreshTokens[self.taskUser]
-
-	def on_stop(self):
-		print "Running on_stop method - trying to stop and delete workspace with id " + self.id
-		if self.getWorkspaceStatus(self.id) == "STOPPING":
-			self.waitForWorkspaceToStop(self.id)
-		if self.getWorkspaceStatus(self.id) != "STOPPED":
-			self.stopWorkspace(self.id)
-			self.waitForWorkspaceToStop(self.id)
-		self.deleteWorkspace(self.id)
-		self.deleteExistingWorkspaces()
 
 	@task
 	def createStartDeleteWorkspace(self):

--- a/che-start-workspace/removeWorkspaces.sh
+++ b/che-start-workspace/removeWorkspaces.sh
@@ -1,0 +1,33 @@
+while IFS= read -r tokens
+do
+  token=$(echo $tokens| cut -d';' -f 1)
+
+  response=$(curl -H "Authorization: Bearer $token" $CHE_SERVER_URL/api/workspace/)
+  ids=$(echo $response  | jq --raw-output '.[] | .id')
+  statuses=$(echo $response  | jq --raw-output '.[] | .status')
+  idarr=($ids)
+  statusarr=($statuses)
+  counter=0
+
+  for i in "${!idarr[@]}"; do
+    if [[ "${statusarr[$i]}" = "STOPPED" ]]; then
+        echo "Deleting workspace: ${idarr[$i]}"
+        curl -H "Authorization: Bearer $token" -X DELETE $CHE_SERVER_URL/api/workspace/${idarr[$i]}
+    else
+        curl -H "Authorization: Bearer $token" -X DELETE $CHE_SERVER_URL/api/workspace/${idarr[$i]}/runtime
+        echo "Waiting for workspace to stop"
+        while true;
+        do
+          resp=$(curl -H "Authorization: Bearer $token" -X GET $CHE_SERVER_URL/api/workspace/${idarr[$i]})
+          status=$(echo $resp | jq --raw-output '.status')
+          if [ $status = "STOPPED" ]; then
+            break
+          else
+            echo "Status is $status, waiting for STOPPED"
+          fi
+        done
+        echo "Deleting workspace: ${idarr[$i]}"
+        curl -H "Authorization: Bearer $token" -X DELETE $CHE_SERVER_URL/api/workspace/${idarr[$i]}
+    fi
+  done
+done < "$TOKENS_FILE"

--- a/che-start-workspace/run.sh
+++ b/che-start-workspace/run.sh
@@ -95,7 +95,8 @@ else
 	echo " Run Locust locally"
 	$COMMON/__start-locust-master-standalone.sh
 fi
-echo " Run test for $DURATION seconds"
+endtime=$(date -d "+$DURATION seconds" +%X)
+echo " Run test for $DURATION seconds (will ends at $endtime)"
 
 sleep $DURATION
 if [ "$RUN_LOCALLY" != "true" ]; then
@@ -107,6 +108,10 @@ if [ "$RUN_LOCALLY" != "true" ]; then
 else
 	$COMMON/__stop-locust-master-standalone.sh TERM
 fi
+
+echo "Removing all workspaces from accounts"
+./removeWorkspaces.sh
+
 
 echo " Extract CSV data from logs:"
 $COMMON/_locust-log-to-csv.sh 'POST createWorkspace' $JOB_BASE_NAME-$BUILD_NUMBER-locust-master.log
@@ -211,7 +216,7 @@ function distribution_2_csv {
  echo "Check for errors in Locust master log"
 
  REPORT_COUNT=`wc -l < $JOB_BASE_NAME-$BUILD_NUMBER-report_distribution.csv`
- EXPECTED_REPORT_COUNT=9
+ EXPECTED_REPORT_COUNT=8
  EXIT_CODE=0
  if [[ "0" -ne `cat $JOB_BASE_NAME-$BUILD_NUMBER-locust-master.log | grep 'Error report' | wc -l` ]]; then
     echo 'THERE WERE ERRORS OR FAILURES WHILE SENDING REQUESTS';
@@ -223,3 +228,5 @@ function distribution_2_csv {
     echo 'NO ERRORS OR FAILURES DETECTED';
  fi
  exit $EXIT_CODE
+
+


### PR DESCRIPTION
Some failures are caused by improper behaviour of on_stop method. Therefore method was removed and replaced by bash script executed after all locust slaves are terminated. This should make tests more stable. 