### PR TITLE
Send mail if build fails.

### DIFF
--- a/che-start-workspace/jenkins-job/che-start-workspace.yml
+++ b/che-start-workspace/jenkins-job/che-start-workspace.yml
@@ -112,6 +112,9 @@
     description: null
     disabled: false
     publishers:
+      - email:
+          recipients: kkanova@redhat.com rhopp@redhat.com tdancs@redhat.com
+          notify-every-unstable-build: true
        - archive:
            artifacts: 'che-start-workspace/*.log,che-start-workspace/*.png,che-start-workspace/*.csv,che-start-workspace/*.html'
            allow-empty: 'true'

--- a/che-start-workspace/run.sh
+++ b/che-start-workspace/run.sh
@@ -221,7 +221,8 @@ function distribution_2_csv {
  if [[ "0" -ne `cat $JOB_BASE_NAME-$BUILD_NUMBER-locust-master.log | grep 'Error report' | wc -l` ]]; then
     echo 'THERE WERE ERRORS OR FAILURES WHILE SENDING REQUESTS';
     EXIT_CODE=1;
- elif [[ REPORT_COUNT -ne $EXPECTED_REPORT_COUNT ]]; then
+ #elif [[ REPORT_COUNT -ne $EXPECTED_REPORT_COUNT ]]; then
+ elif [[ REPORT_COUNT -ne 12 ]]; then
     echo "THERE WERE NOT CORRECT AMOUNT OF RECORDS IN REPORT FILE expected $EXPECTED_REPORT_COUNT gotten $REPORT_COUNT";
     EXIT_CODE=1;
  else


### PR DESCRIPTION
If build fails, sending emails to rhopp, kkanova and tdancs. Failure in code was created so needed to be reverted after sending e-mails is tested. 