### PR TITLE
Replace MULTI_TENANT_CHE_SERVER_URL with CHE_SERVER_URL when starting

### DIFF
--- a/arquillian-extension-che/src/main/java/com/redhat/arquillian/che/CheWorkspaceManager.java
+++ b/arquillian-extension-che/src/main/java/com/redhat/arquillian/che/CheWorkspaceManager.java
@@ -157,7 +157,7 @@ public class CheWorkspaceManager {
             props.setProperty("GITHUB_TOKEN_URL", "https://auth." + configurationInstance.get().getOsioUrlPart()
                     + "/api/token?for=https://github.com");
             props.setProperty(
-                    "MULTI_TENANT_CHE_SERVER_URL",
+                    "CHE_SERVER_URL",
                     configurationInstance.get().getCustomCheServerFullURL().isEmpty()
                     ? "https://rhche." + configurationInstance.get().getOsioUrlPart()
                     : configurationInstance.get().getCustomCheServerFullURL()


### PR DESCRIPTION
che-starter.

Since https://github.com/redhat-developer/che-starter/pull/297  was
merged, tests were unable to start workspace on prod.

Fixes #233

Signed-off-by: Radim Hopp <rhopp@redhat.com>