### PR TITLE
Adding new stack type - NONE.

### DIFF
--- a/arquillian-extension-che/src/main/java/com/redhat/arquillian/che/CheWorkspaceManager.java
+++ b/arquillian-extension-che/src/main/java/com/redhat/arquillian/che/CheWorkspaceManager.java
@@ -15,6 +15,7 @@ import com.redhat.arquillian.che.config.CheExtensionConfiguration;
 import com.redhat.arquillian.che.provider.CheWorkspaceProvider;
 import com.redhat.arquillian.che.resource.CheWorkspace;
 import com.redhat.arquillian.che.resource.CheWorkspaceStatus;
+import com.redhat.arquillian.che.resource.Stack;
 import com.redhat.arquillian.che.resource.StackService;
 import com.redhat.arquillian.che.service.CheWorkspaceService;
 import org.apache.log4j.Logger;
@@ -97,7 +98,7 @@ public class CheWorkspaceManager {
                 createdWkspc = cheWorkspaceInstanceProducer.get();
                 if (!(createdWkspc.getStack().equals(workspaceAnnotation.stackID()))) {
                     CheWorkspaceService.stopWorkspace(cheWorkspaceInstanceProducer.get(), bearerToken);
-                    CheWorkspaceService.deleteWorkspace(cheWorkspaceInstanceProducer.get(), bearerToken);
+                    waitingForDeletion.add(cheWorkspaceInstanceProducer.get());
                     createWorkspace(workspaceAnnotation);
                     LOG.info("Workspace " + createdWkspc.getName() + " created and started.");
                 }
@@ -123,7 +124,8 @@ public class CheWorkspaceManager {
 
     private boolean setRunningWorkspace(Workspace annotation) {
         CheWorkspace workspace = CheWorkspaceService.getRunningWorkspace();
-        if (workspace == null) {
+        if (workspace == null || workspace.getStack().equals(Stack.NONE)) {
+            LOG.info("None suitable running workspace found - creating new one.");
             return false;
         } else {
             LOG.info("Running workspace found - reusing.");

--- a/arquillian-extension-che/src/main/java/com/redhat/arquillian/che/resource/Stack.java
+++ b/arquillian-extension-che/src/main/java/com/redhat/arquillian/che/resource/Stack.java
@@ -13,7 +13,8 @@ package com.redhat.arquillian.che.resource;
 public enum Stack {
 
 	VERTX("vert.x"),
-	NODEJS("nodejs-centos");
+	NODEJS("nodejs-centos"),
+	NONE("none");
 
 	private String stack;
 

--- a/arquillian-extension-che/src/main/java/com/redhat/arquillian/che/resource/StackService.java
+++ b/arquillian-extension-che/src/main/java/com/redhat/arquillian/che/resource/StackService.java
@@ -20,20 +20,13 @@ public class StackService {
 		if (stack == Stack.NODEJS)
 			return Constants.CREATE_WORKSPACE_REQUEST_NODEJS_JSON;
 		return null;
+
 	}
 
 	public static Stack getStackType(String projectType){
 		if(projectType.equals("maven")) return Stack.VERTX;
 		if(projectType.equals("node-js")) return Stack.NODEJS;
-		return null;
-	}
-
-	public static Stack getStackTypeFromJson(String json){
-		if(json.contains(Stack.NODEJS.toString())){
-			return  Stack.NODEJS;
-		} else if(json.contains(Stack.VERTX.toString())){
-			return Stack.VERTX;
-		}
+		if(projectType.equals("none")) return Stack.NONE;
 		return null;
 	}
 }

--- a/arquillian-extension-che/src/main/java/com/redhat/arquillian/che/resource/StackService.java
+++ b/arquillian-extension-che/src/main/java/com/redhat/arquillian/che/resource/StackService.java
@@ -15,18 +15,26 @@ import com.redhat.arquillian.che.util.Constants;
 public class StackService {
 
 	public static String getPathOfJsonConfig(Stack stack){
-		if (stack == Stack.VERTX)
+		if (stack == Stack.VERTX){
 			return Constants.CREATE_WORKSPACE_REQUEST_VERTX_JSON;
-		if (stack == Stack.NODEJS)
+		}
+		if (stack == Stack.NODEJS){
 			return Constants.CREATE_WORKSPACE_REQUEST_NODEJS_JSON;
+		}
 		return null;
 
 	}
 
 	public static Stack getStackType(String projectType){
-		if(projectType.equals("maven")) return Stack.VERTX;
-		if(projectType.equals("node-js")) return Stack.NODEJS;
-		if(projectType.equals("none")) return Stack.NONE;
+		if(projectType.equals("maven")) {
+			return Stack.VERTX;
+		}
+		if(projectType.equals("node-js")) {
+			return Stack.NODEJS;
+		}
+		if(projectType.equals("none")) {
+			return Stack.NONE;
+		}
 		return null;
 	}
 }

--- a/arquillian-extension-che/src/main/java/com/redhat/arquillian/che/service/CheWorkspaceService.java
+++ b/arquillian-extension-che/src/main/java/com/redhat/arquillian/che/service/CheWorkspaceService.java
@@ -13,6 +13,7 @@ package com.redhat.arquillian.che.service;
 import java.io.IOException;
 import java.util.List;
 
+import com.jayway.jsonpath.JsonPathException;
 import com.redhat.arquillian.che.config.CheExtensionConfiguration;
 import com.redhat.arquillian.che.resource.Stack;
 import com.redhat.arquillian.che.resource.StackService;
@@ -95,8 +96,8 @@ public class CheWorkspaceService {
         String type;
         try{
              type = JsonPath.read(jsonDocument, path);
-        }catch (RuntimeException e){
-            //no stack type setted
+        }catch (JsonPathException e){
+            //no stack type set
             type = "none";
         }
         return StackService.getStackType(type);

--- a/arquillian-extension-che/src/main/java/com/redhat/arquillian/che/service/CheWorkspaceService.java
+++ b/arquillian-extension-che/src/main/java/com/redhat/arquillian/che/service/CheWorkspaceService.java
@@ -92,7 +92,13 @@ public class CheWorkspaceService {
     }
 
     private static Stack getWorkspaceStack(Object jsonDocument, String path) {
-        String type = JsonPath.read(jsonDocument, path);
+        String type;
+        try{
+             type = JsonPath.read(jsonDocument, path);
+        }catch (RuntimeException e){
+            //no stack type setted
+            type = "none";
+        }
         return StackService.getStackType(type);
     }
 


### PR DESCRIPTION
When workspace type is not set, this field does not exist and test failed. Now it sets type to NONE and when checking it creates new workspace. 