### PR TITLE
Fix starting of workspace

### DIFF
--- a/arquillian-extension-che/src/main/java/com/redhat/arquillian/che/CheWorkspaceManager.java
+++ b/arquillian-extension-che/src/main/java/com/redhat/arquillian/che/CheWorkspaceManager.java
@@ -120,15 +120,8 @@ public class CheWorkspaceManager {
 
             LOG.info("Workspace " + createdWkspc.getName() + " created and started.");
         } else if (!CheWorkspaceService.getWorkspaceStatus(createdWkspc, bearerToken).equals(CheWorkspaceStatus.RUNNING.toString())) { //provided workspace is stopped
-            boolean isStarted = CheWorkspaceService.startWorkspace(createdWkspc);
-            if (isStarted) {
-                LOG.info("Workspace " + createdWkspc.getName() + " started.");
-            } else {
-                LOG.info("Can not start given workspace! Creating new one.");
-                createWorkspace(workspaceAnnotation);
-            }
+            CheWorkspaceService.startWorkspace(createdWkspc);
         }
-        
         cleanupPreferences();
     }
 
@@ -184,8 +177,6 @@ public class CheWorkspaceManager {
 
         //creating and starting new workspace
         cheWorkspaceInstanceProducer.set(provider.createCheWorkspace(StackService.getPathOfJsonConfig(workspaceAnnotation.stackID())));
-        CheWorkspaceService.waitUntilWorkspaceGetsToState(cheWorkspaceInstanceProducer.get(), CheWorkspaceStatus.RUNNING.getStatus(), bearerToken);
-
     }
 
     private void startCheStarter() {

--- a/arquillian-extension-che/src/main/java/com/redhat/arquillian/che/provider/CheWorkspaceProvider.java
+++ b/arquillian-extension-che/src/main/java/com/redhat/arquillian/che/provider/CheWorkspaceProvider.java
@@ -94,7 +94,7 @@ public class CheWorkspaceProvider {
         response.close();
         cheStarterClient.close();
         CheWorkspace workspace = CheWorkspaceService.getWorkspaceFromDocument(jsonDocument);
-        startWorkspace(workspace);
+        CheWorkspaceService.startWorkspace(workspace);
         return workspace;
     }
 
@@ -124,7 +124,7 @@ public class CheWorkspaceProvider {
 
         }
         if(!CheWorkspaceService.getWorkspaceStatus(workspace, keycloakToken).equals(CheWorkspaceStatus.RUNNING.toString())){
-            startWorkspace(workspace);
+            CheWorkspaceService.startWorkspace(workspace);
         }
         return workspace;
     }
@@ -133,24 +133,6 @@ public class CheWorkspaceProvider {
         return configuration;
     }
 
-    private void startWorkspace(CheWorkspace workspace) {
-        Response response;
-        LOG.info("Workspace self link:" + workspace.getSelfLink());
-        RestClient cheServerClient = new RestClient(workspace.getSelfLink());
-        response = cheServerClient.sendRequest(
-                "/runtime",
-                RequestType.POST,
-                null,
-                keycloakToken
-        );
-        if (!response.isSuccessful()) {
-            throw new IllegalStateException("Che server failed to start workspace:" + response.message());
-        } else {
-            LOG.info("Start request sent successfully:" + response.message());
-        }
-        cheServerClient.close();
-    }
-    
     public Object callGetGithubTokenEndpoint() {
     	RestClient authClient = new RestClient("https://auth." + configuration.getOsioUrlPart() + "/");
 		Response authResponse = authClient.sendRequest("api/token?for=https://github.com", RequestType.GET, null,


### PR DESCRIPTION
If workspace doesn't start, throw RuntimeException. No boolean return values needed then.