### PR TITLE
rhche.openshift.io is not valid URL anymore.

### DIFF
--- a/arquillian-extension-che/src/main/java/com/redhat/arquillian/che/CheWorkspaceManager.java
+++ b/arquillian-extension-che/src/main/java/com/redhat/arquillian/che/CheWorkspaceManager.java
@@ -194,7 +194,7 @@ public class CheWorkspaceManager {
             props.setProperty(
                     "CHE_SERVER_URL",
                     configurationInstance.get().getCustomCheServerFullURL().isEmpty()
-                    ? "https://rhche." + configurationInstance.get().getOsioUrlPart()
+                    ? "https://che." + configurationInstance.get().getOsioUrlPart()
                     : configurationInstance.get().getCustomCheServerFullURL()
             );
             EmbeddedMaven

--- a/che-start-workspace/README.md
+++ b/che-start-workspace/README.md
@@ -2,7 +2,7 @@
 These tests are intended to measure performance of the REST endpoints of creating/starting/stopping/deleting workspace. It serves as monitoring of service on daily basis.
 
 ## Environment
-The tested server is the OSIO (https://che.openshift.io or https://rhche.openshift.io).
+The tested server is the OSIO (https://che.openshift.io).
 
 
 ## Test setup

--- a/che-start-workspace/_setenv.sh
+++ b/che-start-workspace/_setenv.sh
@@ -13,8 +13,7 @@
 #export AUTH_SERVER_URL=https://auth.openshift.io
 
 # Che server url.
-#export CHE_SERVER_URL=https://che.openshift.io
-export CHE_SERVER_URL=https://rhche.openshift.io
+export CHE_SERVER_URL=https://che.openshift.io
 
 # Locust SSH user. (Only for RUN_LOCALLY != true)
 #export SSH_USER=centos

--- a/job-definitions/che-start-workspace.yml
+++ b/job-definitions/che-start-workspace.yml
@@ -51,8 +51,7 @@
            description: Auth server machine address.
        - string:
            name: CHE_SERVER_URL
-           #default: https://che.openshift.io
-           default: https://rhche.openshift.io
+           default: https://che.openshift.io
            description: Che server machine address.
        - string:
            name: SSH_USER


### PR DESCRIPTION
Signed-off-by: Radim Hopp <rhopp@redhat.com>