### PR TITLE
Fix removing workspaces at the end of tests.

### DIFF
--- a/che-start-workspace/removeWorkspaces.sh
+++ b/che-start-workspace/removeWorkspaces.sh
@@ -1,3 +1,5 @@
+tokens=$1
+
 while IFS= read -r tokens
 do
   token=$(echo $tokens| cut -d';' -f 1)
@@ -8,7 +10,6 @@ do
   idarr=($ids)
   statusarr=($statuses)
   counter=0
-
   for i in "${!idarr[@]}"; do
     if [[ "${statusarr[$i]}" = "STOPPED" ]]; then
         echo "Deleting workspace: ${idarr[$i]}"
@@ -30,4 +31,4 @@ do
         curl -H "Authorization: Bearer $token" -X DELETE $CHE_SERVER_URL/api/workspace/${idarr[$i]}
     fi
   done
-done < "$TOKENS_FILE"
+done < "$tokens"

--- a/che-start-workspace/run.sh
+++ b/che-start-workspace/run.sh
@@ -35,12 +35,12 @@ cat $MVN_LOG | grep login-users-log > $LOGIN_USERS_OAUTH2_LOG
 chmod +r $TOKENS_FILE
 
 endtime=$(date -d "+$DURATION seconds" +%X)
-echo " Tests will end approximately at $endtime)"
+echo " Tests will end approximately at $endtime"
 
 $COMMON/_execute.sh
 
 echo "Removing all workspaces from accounts"
-./removeWorkspaces.sh
+./removeWorkspaces.sh $TOKENS_FILE
 
 while read p; do
   echo $p | cut -d';' -f 3 >> $LOG_DIR/$JOB_BASE_NAME-$BUILD_NUMBER-locust-master.log


### PR DESCRIPTION
At the end of che-start-workspace tests the script for removing workspaces is failing. Fix it to have no workspaces at the end of tests. 