### PR TITLE
Add timeout to jenkins job pipeline tests

### DIFF
--- a/che-start-workspace/start-workspace-test-ephemeral.groovy
+++ b/che-start-workspace/start-workspace-test-ephemeral.groovy
@@ -13,6 +13,9 @@ pipeline {
         LOG_DIR = ""
         ZABBIX_FILE = ""
     }
+    options {
+        timeout(time: 13, unit: 'MINUTES') 
+    }
     stages {
         stage ("Prepairing environment") {
             steps {

--- a/che-start-workspace/start-workspace-test.groovy
+++ b/che-start-workspace/start-workspace-test.groovy
@@ -13,6 +13,9 @@ pipeline {
         LOG_DIR = ""
         ZABBIX_FILE = ""
     }
+    options {
+        timeout(time: 13, unit: 'MINUTES') 
+    }
     stages {
         stage ("Prepairing environment") {
             steps {


### PR DESCRIPTION
This PR should prevent job stacking when the jobs take longer than expected.